### PR TITLE
Add Wikipedia request caching, various cleanup

### DIFF
--- a/app/looper.py
+++ b/app/looper.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 import requests
 from bs4 import BeautifulSoup
+from .utils import lru_cache
 
 def getLinkInPara(para_list):
     for para in para_list:
@@ -19,6 +20,7 @@ def getLinkInPara(para_list):
                 return next_link
     return None
 
+@lru_cache(maxsize=65536)
 def getNextLink(link):
     wiki_url = "http://en.wikipedia.org/wiki/"
 

--- a/app/looper.py
+++ b/app/looper.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import requests
 from bs4 import BeautifulSoup
 
@@ -56,7 +57,7 @@ def getNextLink(link):
             
     if next_link is not None:
         args = next_link.split("/")[-1]
-        print args
+        print(args)
         return args
     else:
         return "--ERROR3--"

--- a/app/looper.py
+++ b/app/looper.py
@@ -9,9 +9,9 @@ def getLinkInPara(para_list):
         for tag in para.children:
             if tag.name is None and tag.string is not None:
                 if '(' in tag.string.strip():
-                    bracket = bracket + 1
+                    bracket += 1
                 if ')' in tag.string.strip():
-                    bracket = bracket - 1
+                    bracket -= 1
 
             if tag.name == 'a' and bracket == 0:
                 next_link = tag['href']
@@ -24,7 +24,7 @@ def getLinkInPara(para_list):
 def getNextLink(link):
     wiki_url = "http://en.wikipedia.org/wiki/"
 
-    r = requests.get(wiki_url+link)
+    r = requests.get(wiki_url + link)
     if r.status_code != 200:
         print(link + "Not a valid wiki link")
         return "--ERROR1--"
@@ -33,33 +33,25 @@ def getNextLink(link):
     soup = BeautifulSoup(data)
     div = soup.find_all(id="mw-content-text")[0]
 
-    para_list = []
-    for child in div.children:
-        if child.name == 'p':
-            para_list.append(child)
+    para_list = [child for child in div.children if child.name == 'p']
 
-    next_link = None
-    if para_list is not None:
-        next_link = getLinkInPara(para_list)
+    next_link = getLinkInPara(para_list)
 
     if next_link is None:
-        ul = None
         for child in div.children:
             if child.name == 'ul':
                 ul = child
                 break
-
-        if ul is None:
+        else:
             return "--ERROR2--"
 
         try:
             next_link = ul.li.a['href']
+            if next_link is None:  # this should never happen
+                return "--ERROR3--"
         except:
             return "--ERROR2--"
-            
-    if next_link is not None:
-        args = next_link.split("/")[-1]
-        print(args)
-        return args
-    else:
-        return "--ERROR3--"
+
+    args = next_link.split("/")[-1]
+    print(args)
+    return args

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,27 @@
+try:
+    from functools import lru_cache
+except ImportError:
+    from functools import wraps
+
+    def lru_cache(maxsize=128):
+        """Simple cache decorator with limited size.
+
+        Cache will delete a random key once size limit is
+        reached."""
+
+        def decorator(func):
+            cache = {}
+
+            @wraps(func)
+            def wrapped(*args):
+                if args in cache:
+                    return cache[args]
+                result = func(*args)
+                if len(cache) >= maxsize:
+                    cache.popitem()
+                cache[args] = result
+                return result
+
+            return wrapped
+
+        return decorator


### PR DESCRIPTION
Deleted some redundant code and also made it forward-compatible with Python 3.

The caching should speed up requests by a lot when requesting a cached page. The fallback `lru_cache` (used on Python 2) isn't very efficient, so I highly recommend using Python 3 if possible. 
